### PR TITLE
Make ident compatible with mainline godef API.

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -24,7 +24,7 @@ func getScope(filepath string) *ast.Scope {
 }
 
 func getDefPosition(expr ast.Expr) *token.Position {
-	obj, _ := types.ExprType(expr, types.DefaultImporter)
+	obj, _ := types.ExprType(expr, types.DefaultImporter, fileset)
 	if obj == nil {
 		return nil
 	}

--- a/findReferences.go
+++ b/findReferences.go
@@ -54,7 +54,7 @@ func (def Definition) findReferences(searchpath string, recursive bool) (chan Re
 				return
 			}
 		}()
-		f, err := parser.ParseFile(fileset, filepath, nil, 0, getScope(filepath))
+		f, err := parser.ParseFile(fileset, filepath, nil, 0, getScope(filepath), nil)
 		if failed(err) {
 			return
 		}
@@ -71,7 +71,7 @@ func (def Definition) findReferences(searchpath string, recursive bool) (chan Re
 				return
 			}
 		}()
-		result, err := parser.ParseDir(fileset, dirpath, filter, 0)
+		result, err := parser.ParseDir(fileset, dirpath, filter, 0, nil)
 		if failed(err) {
 			return
 		}

--- a/lookup.go
+++ b/lookup.go
@@ -11,7 +11,7 @@ import (
 func lookup(filepath string, offset int) (Definition, error) {
 	def := Definition{}
 
-	f, err := parser.ParseFile(fileset, filepath, nil, 0, getScope(filepath))
+	f, err := parser.ParseFile(fileset, filepath, nil, 0, getScope(filepath), nil)
 	if err != nil {
 		return def, err
 	}
@@ -47,7 +47,7 @@ func lookup(filepath string, offset int) (Definition, error) {
 		return def, errors.New("could not find definition of identifier")
 	}
 
-	obj, _ := types.ExprType(ident, types.DefaultImporter)
+	obj, _ := types.ExprType(ident, types.DefaultImporter, fileset)
 	def.Name = obj.Name
 	def.Position = *pos
 	return def, nil


### PR DESCRIPTION
rogpeppe introduced incompatible API changes in May, 2016.  ident never
adapted itself to them.  This commit makes ident API-compatible and
fixes redefiance/ident#4.

Package parser in rogpeppe's godef gracefully handles `nil` values for the `type ImportPathToName func(path string, fromDir string) (string, error)` parameters added to its functions by falling back onto its internal implementation.
